### PR TITLE
Travis CI: Add some tests to find Python 3 compatibility issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: python
+install: pip install flake8
+script: flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics


### PR DESCRIPTION
$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./sitefab.py:50:21: E999 SyntaxError: invalid syntax
        print colored("[%s]" % category, 'yellow')
                    ^
./plugins/site/rendering/nlp/nlp.py:53:22: F821 undefined name 'xrange'
            for i in xrange(num_words):
                     ^
./plugins/site/rendering/nlp/nlp.py:56:26: F821 undefined name 'xrange'
                for j in xrange(start, stop):
                         ^
./plugins/site/rendering/nlp/nlp.py:98:29: F821 undefined name 'xrange'
            for gram_len in xrange(min_gram_len, max_gram_len + 1):
                            ^
./plugins/site/preparsing/responsive_images/responsive_images.py:19:25: E999 SyntaxError: invalid syntax
def generate_thumbnails((images, params)):
                        ^
./SiteFab/Plugins.py:299:34: E999 SyntaxError: invalid syntax
            print "%s\t%s\t%s\t%s" % (name, ok, skip, err)
                                 ^
./SiteFab/nlp.py:69:50: F821 undefined name 'unicode'
    if isinstance(slug, str) or isinstance(slug, unicode):
                                                 ^
./SiteFab/SiteFab.py:185:31: E999 SyntaxError: invalid syntax
        print "\nPosts plugins"
                              ^
./SiteFab/linter/frontmatter.py:192:63: F821 undefined name 'unicode'
    if not isinstance(banner, str) and not isinstance(banner, unicode):
                                                              ^
./SiteFab/linter/frontmatter.py:224:57: F821 undefined name 'unicode'
    if not isinstance(url, str) and not isinstance(url, unicode):
                                                        ^
./SiteFab/parser/markdown.py:38:72: E999 SyntaxError: invalid syntax
                        print "error can't detect video id for link: %s" % link
                                                                       ^
./SiteFab/parser/frontmatter.py:79:30: E999 SyntaxError: invalid syntax
        except yaml.YAMLError, exc:
                             ^
./SiteFab/admin/build.py:97:32: E999 SyntaxError: invalid syntax
    print plugin_config_filename
                               ^
./tests/test_sitefab_init.py:24:19: E999 SyntaxError: invalid syntax
        print fname
                  ^
./tests/test_linter_frontmatter.py:226:25: E999 SyntaxError: invalid syntax
            print results
                        ^
./tests/test_linter_images.py:47:21: E999 SyntaxError: invalid syntax
        print results
                    ^
10    E999 SyntaxError: invalid syntax
6     F821 undefined name 'unicode'
16
```